### PR TITLE
Add singleton pages and desk structure

### DIFF
--- a/deskStructure.ts
+++ b/deskStructure.ts
@@ -1,7 +1,33 @@
 // Created following https://youtu.be/YMX2TX3vIAc
 import { StructureBuilder } from "sanity/desk"
-import { HomeIcon, CogIcon } from "@sanity/icons"
+import { HomeIcon, CogIcon, DocumentIcon } from "@sanity/icons"
 // Find more icons at https://icons.sanity.build/
+
+const sitePages = [
+    {
+        section: "About Us",
+        pages: [
+            { title: "Leadership", schema: "leadershipPage" },
+            { title: "Cultural Stance", schema: "culturePage" },
+            { title: "History of LYF", schema: "historyPage" },
+        ],
+    },
+    {
+        section: "Camp",
+        pages: [
+            { title: "What is LYF Camp?", schema: "lyfCampPage" },
+            { title: "FAQs", schema: "faqPage" },
+        ],
+    },
+    {
+        section: "Get Involved",
+        pages: [
+            { title: "Join Our Team", schema: "joinOurTeamPage" },
+            { title: "Donate", schema: "donatePage" },
+            { title: "Cookbook", schema: "cookbookPage" },
+        ],
+    },
+]
 
 export default (S: StructureBuilder) =>
     S.list()
@@ -31,6 +57,35 @@ export default (S: StructureBuilder) =>
                                         .schemaType("homePage")
                                         .documentId("homePage")
                                 ),
+                            // Show the site map as pages to be edited
+                            ...sitePages.map(({ section, pages }) =>
+                                S.listItem()
+                                    .title(section)
+                                    .child(
+                                        S.list()
+                                            .title(section)
+                                            .items(
+                                                // Display an editor for each of the pages
+                                                pages.map(
+                                                    ({ title, schema }) => {
+                                                        return S.listItem()
+                                                            .title(title)
+                                                            .icon(DocumentIcon)
+                                                            .child(
+                                                                S.editor()
+                                                                    .id(schema)
+                                                                    .schemaType(
+                                                                        schema
+                                                                    )
+                                                                    .documentId(
+                                                                        schema
+                                                                    )
+                                                            )
+                                                    }
+                                                )
+                                            )
+                                    )
+                            ),
                         ])
                 ),
             S.divider(),
@@ -58,8 +113,14 @@ export default (S: StructureBuilder) =>
             // The rest of the documents
             ...S.documentTypeListItems().filter(
                 (item) =>
-                    !["siteSettings", "campYear", "homePage"].includes(
-                        item.getId()
-                    )
+                    ![
+                        "siteSettings",
+                        "campYear",
+                        "homePage",
+                        // Filter out all of the schemas for the site pages
+                        ...sitePages.flatMap(({ pages }) =>
+                            pages.map(({ schema }) => schema)
+                        ),
+                    ].includes(item.getId())
             ),
         ])

--- a/schemas/schema.ts
+++ b/schemas/schema.ts
@@ -1,6 +1,14 @@
 // Import the singleton schemas
 import siteSettings from './singletons/siteSettings'
 import homePage from "./singletons/homePage"
+import culturePage from "./singletons/about-us/culturePage"
+import historyPage from "./singletons/about-us/historyPage"
+import leadershipPage from "./singletons/about-us/leadershipPage"
+import faqPage from "./singletons/camp/faqPage"
+import lyfCampPage from "./singletons/camp/lyfCampPage"
+import cookbookPage from "./singletons/get-involved/cookbookPage"
+import joinOurTeamPage from "./singletons/get-involved/joinOurTeamPage"
+import donatePage from "./singletons/get-involved/donatePage"
 
 // Import the document schemas
 import campYear from './documents/campYear'
@@ -16,6 +24,17 @@ export default [
   // Singletons
   siteSettings,
   homePage,
+  // about-us
+  culturePage,
+  historyPage,
+  leadershipPage,
+  // camp
+  faqPage,
+  lyfCampPage,
+  // get-involved
+  cookbookPage,
+  joinOurTeamPage,
+  donatePage,
 
   // Documents
   campYear,

--- a/schemas/singletons/about-us/culturePage.ts
+++ b/schemas/singletons/about-us/culturePage.ts
@@ -1,0 +1,22 @@
+import { DocumentDefinition } from "sanity"
+
+const schema: DocumentDefinition = {
+    name: "culturePage",
+    title: "Culture Page",
+    type: "document",
+    fields: [
+        {
+            name: "mainHeader",
+            title: "Main Header",
+            type: "string",
+            validation: (Rule) => Rule.required(),
+        },
+        {
+            name: "subHeader",
+            title: "Sub Header",
+            type: "text",
+        },
+    ],
+}
+
+export default schema

--- a/schemas/singletons/about-us/historyPage.ts
+++ b/schemas/singletons/about-us/historyPage.ts
@@ -1,0 +1,22 @@
+import { DocumentDefinition } from "sanity"
+
+const schema: DocumentDefinition = {
+    name: "historyPage",
+    title: "History Page",
+    type: "document",
+    fields: [
+        {
+            name: "mainHeader",
+            title: "Main Header",
+            type: "string",
+            validation: (Rule) => Rule.required(),
+        },
+        {
+            name: "subHeader",
+            title: "Sub Header",
+            type: "text",
+        },
+    ],
+}
+
+export default schema

--- a/schemas/singletons/about-us/leadershipPage.ts
+++ b/schemas/singletons/about-us/leadershipPage.ts
@@ -1,0 +1,22 @@
+import { DocumentDefinition } from "sanity"
+
+const schema: DocumentDefinition = {
+    name: "leadershipPage",
+    title: "Leadership Page",
+    type: "document",
+    fields: [
+        {
+            name: "mainHeader",
+            title: "Main Header",
+            type: "string",
+            validation: (Rule) => Rule.required(),
+        },
+        {
+            name: "subHeader",
+            title: "Sub Header",
+            type: "text",
+        },
+    ],
+}
+
+export default schema

--- a/schemas/singletons/camp/faqPage.ts
+++ b/schemas/singletons/camp/faqPage.ts
@@ -1,0 +1,22 @@
+import { DocumentDefinition } from "sanity"
+
+const schema: DocumentDefinition = {
+    name: "faqPage",
+    title: "FAQ Page",
+    type: "document",
+    fields: [
+        {
+            name: "mainHeader",
+            title: "Main Header",
+            type: "string",
+            validation: (Rule) => Rule.required(),
+        },
+        {
+            name: "subHeader",
+            title: "Sub Header",
+            type: "text",
+        },
+    ],
+}
+
+export default schema

--- a/schemas/singletons/camp/lyfCampPage.ts
+++ b/schemas/singletons/camp/lyfCampPage.ts
@@ -1,0 +1,22 @@
+import { DocumentDefinition } from "sanity"
+
+const schema: DocumentDefinition = {
+    name: "lyfCampPage",
+    title: "LYF Camp Page",
+    type: "document",
+    fields: [
+        {
+            name: "mainHeader",
+            title: "Main Header",
+            type: "string",
+            validation: (Rule) => Rule.required(),
+        },
+        {
+            name: "subHeader",
+            title: "Sub Header",
+            type: "text",
+        },
+    ],
+}
+
+export default schema

--- a/schemas/singletons/get-involved/cookbookPage.ts
+++ b/schemas/singletons/get-involved/cookbookPage.ts
@@ -1,0 +1,22 @@
+import { DocumentDefinition } from "sanity"
+
+const schema: DocumentDefinition = {
+    name: "cookbookPage",
+    title: "Cookbook Page",
+    type: "document",
+    fields: [
+        {
+            name: "mainHeader",
+            title: "Main Header",
+            type: "string",
+            validation: (Rule) => Rule.required(),
+        },
+        {
+            name: "subHeader",
+            title: "Sub Header",
+            type: "text",
+        },
+    ],
+}
+
+export default schema

--- a/schemas/singletons/get-involved/donatePage.ts
+++ b/schemas/singletons/get-involved/donatePage.ts
@@ -1,0 +1,22 @@
+import { DocumentDefinition } from "sanity"
+
+const schema: DocumentDefinition = {
+    name: "donatePage",
+    title: "Donate Page",
+    type: "document",
+    fields: [
+        {
+            name: "mainHeader",
+            title: "Main Header",
+            type: "string",
+            validation: (Rule) => Rule.required(),
+        },
+        {
+            name: "subHeader",
+            title: "Sub Header",
+            type: "text",
+        },
+    ],
+}
+
+export default schema

--- a/schemas/singletons/get-involved/joinOurTeamPage.ts
+++ b/schemas/singletons/get-involved/joinOurTeamPage.ts
@@ -1,0 +1,22 @@
+import { DocumentDefinition } from "sanity"
+
+const schema: DocumentDefinition = {
+    name: "joinOurTeamPage",
+    title: "Join Our Team Page",
+    type: "document",
+    fields: [
+        {
+            name: "mainHeader",
+            title: "Main Header",
+            type: "string",
+            validation: (Rule) => Rule.required(),
+        },
+        {
+            name: "subHeader",
+            title: "Sub Header",
+            type: "text",
+        },
+    ],
+}
+
+export default schema


### PR DESCRIPTION
Added a new singleton for each of the pages defined in https://www.figma.com/file/p3jTW66oX0UTb9uHKXjTFm/LYF-Website-Brainstorm?node-id=739%3A76120&t=VHyK5rk2LyAYGmGm-0

Note that this is very much just structure and no actual content yet. @shialanyu this should be enough for you to get started adding in some of the fields! 