### PR TITLE
What is camp page

### DIFF
--- a/schemas/documents/event.ts
+++ b/schemas/documents/event.ts
@@ -1,0 +1,59 @@
+import { DocumentDefinition } from "sanity"
+
+const schema: DocumentDefinition = {
+  name: "event",
+  title: "Event",
+  type: "document",
+  fields: [
+    {
+      name: "title",
+      title: "Title",
+      type: "string",
+      validation: (Rule) => Rule.required(),
+    },
+    {
+      name: "startDateTime",
+      title: "Start Date and Time",
+      type: "datetime",
+      description: "The date and time of the event. If no time should be shown on the website, put 00:00. Assume the Pacific timezone.",
+      validation: (Rule) => Rule.required(),
+      options: {
+        dateFormat: "MMM D, YYYY",
+        timeFormat: "h:mm A"
+      }
+    },
+    {
+      name: "endDateTime",
+      title: "End Date and Time",
+      type: "datetime",
+      description: "Optional end time",
+      options: {
+        dateFormat: "MMM D, YYYY",
+        timeFormat: "h:mm A"
+      }
+    },
+    {
+      name: "eventImage",
+      title: "Image",
+      type: "image",
+    },
+    {
+      name: "location",
+      title: "Location",
+      type: "text",
+    },
+    {
+      name: "description",
+      title: "Description",
+      type: "portableText",
+    },
+    {
+      name: "button",
+      title: "Button",
+      description: "Optional button for any actions.",
+      type: "button",
+    }
+  ]
+}
+
+export default schema

--- a/schemas/objects/button.ts
+++ b/schemas/objects/button.ts
@@ -10,13 +10,11 @@ const schema: ObjectDefinition = {
             name: "text",
             title: "Text",
             type: "string",
-            validation: (Rule) => Rule.required(),
         },
         {
             name: "link",
             title: "Link",
             type: "string",
-            validation: (Rule) => Rule.required(),
         },
         {
             name: "variant",

--- a/schemas/objects/card.ts
+++ b/schemas/objects/card.ts
@@ -1,0 +1,40 @@
+import { ObjectDefinition } from "sanity"
+
+const schema: ObjectDefinition = {
+  name: "card",
+  title: "Card",
+  description: "Content with a header, description, image, and optional button",
+  type: "object",
+  fields: [
+      {
+          name: "title",
+          title: "Title",
+          type: "string",
+          validation: (Rule) => Rule.required(),
+      },
+      {
+          name: "image",
+          title: "Image",
+          type: "image",
+          validation: (Rule) => Rule.required(),
+      },
+      {
+          name: "description",
+          title: "Description",
+          type: "portableText",
+          validation: (Rule) => Rule.required(),
+      },
+      {
+          name: "button",
+          title: "Button",
+          description: "Optional button",
+          type: "button",
+          options: {
+            collapsible: true,
+            collapsed: true,
+          }
+      }
+  ],
+}
+
+export default schema

--- a/schemas/schema.ts
+++ b/schemas/schema.ts
@@ -13,11 +13,13 @@ import donatePage from "./singletons/get-involved/donatePage"
 // Import the document schemas
 import campYear from "./documents/campYear"
 import person from "./documents/person"
+import event from "./documents/event"
 
 // Import the object schemas
 import portableText from "./objects/portableText"
 import statistic from "./objects/statistic"
 import button from "./objects/button"
+import card from "./objects/card"
 
 // Then we give our schema to the builder and provide the result to Sanity
 export default [
@@ -39,11 +41,14 @@ export default [
     // Documents
     campYear,
     person,
+    event,
 
     // Objects
     portableText,
     statistic,
     button,
+    card,
+    // Objects specific to the FAQ section
     faqSection,
     question,
 ]

--- a/schemas/singletons/camp/lyfCampPage.ts
+++ b/schemas/singletons/camp/lyfCampPage.ts
@@ -1,4 +1,4 @@
-import { DocumentDefinition } from "sanity"
+import { DocumentDefinition, ObjectDefinition } from "sanity"
 
 const schema: DocumentDefinition = {
     name: "lyfCampPage",
@@ -28,7 +28,42 @@ const schema: DocumentDefinition = {
                 },
             ],
         },
-
+        {
+            name: "eventsToDisplay",
+            title: "Upcoming Events",
+            description:
+                "Select references to events to display on the camp page.",
+            type: "array",
+            of: [
+                {
+                    type: "reference",
+                    to: [{ type: "event" }],
+                },
+            ],
+        },
+        {
+            name: "activities",
+            title: "Activities",
+            description:
+                "Activities shown in the workshops and sing-along section",
+            type: "array",
+            of: [
+                {
+                    type: "card",
+                },
+            ],
+        },
+        {
+            name: "community",
+            title: "Community",
+            description: "Aspects of community at LYF",
+            type: "array",
+            of: [
+                {
+                    type: "card",
+                },
+            ],
+        },
     ],
 }
 

--- a/schemas/singletons/camp/lyfCampPage.ts
+++ b/schemas/singletons/camp/lyfCampPage.ts
@@ -16,6 +16,19 @@ const schema: DocumentDefinition = {
             title: "Sub Header",
             type: "text",
         },
+        {
+            name: "headerPhotos",
+            title: "Header Photos",
+            description:
+                "The set of photos to display in the header. Be sure to add alt text in the separate media browser!",
+            type: "array",
+            of: [
+                {
+                    type: "image",
+                },
+            ],
+        },
+
     ],
 }
 


### PR DESCRIPTION
Adding the content for the what is LYF camp page?

- Added an events document schema
- Added a card object schema that we can re-use anytime we have content that's just a header, image, and description. Possibly a button
- Changed button so that not all fields are required so that we can use it optionally in card
- Added sections to the lyfCampPage