### PR TITLE
Add Get Involved page schema

### DIFF
--- a/deskStructure.ts
+++ b/deskStructure.ts
@@ -25,6 +25,7 @@ const sitePages = [
             { title: "Join Our Team", schema: "joinOurTeamPage" },
             { title: "Donate", schema: "donatePage" },
             { title: "Cookbook", schema: "cookbookPage" },
+            { title: "Get Involved", schema: "getInvolvedPage" },
         ],
     },
 ]

--- a/schemas/schema.ts
+++ b/schemas/schema.ts
@@ -9,6 +9,7 @@ import lyfCampPage from "./singletons/camp/lyfCampPage"
 import cookbookPage from "./singletons/get-involved/cookbookPage"
 import joinOurTeamPage from "./singletons/get-involved/joinOurTeamPage"
 import donatePage from "./singletons/get-involved/donatePage"
+import getInvolvedPage from "./singletons/get-involved/getInvolvedPage"
 
 // Import the document schemas
 import campYear from "./documents/campYear"
@@ -37,6 +38,7 @@ export default [
     cookbookPage,
     joinOurTeamPage,
     donatePage,
+    getInvolvedPage,
 
     // Documents
     campYear,

--- a/schemas/singletons/get-involved/getInvolvedPage.ts
+++ b/schemas/singletons/get-involved/getInvolvedPage.ts
@@ -1,0 +1,60 @@
+import { DocumentDefinition } from "sanity"
+
+const schema: DocumentDefinition = {
+    name: "getInvolvedPage",
+    title: "Get Involved Page",
+    type: "document",
+    fields: [
+        {
+            name: "mainHeader",
+            title: "Main Header",
+            type: "string",
+            validation: (Rule) => Rule.required(),
+        },
+        {
+            name: "subHeader",
+            title: "Sub Header",
+            type: "text",
+        },
+        {
+            name: "headerImage",
+            title: "Header Image",
+            description:
+                "Image to display in the header. Add alt text in media browser.",
+            type: "array",
+            of: [
+                {
+                    type: "image",
+                },
+            ],
+        },
+        {
+            name: "involvement",
+            title: "Involvement",
+            description: "Cards with ways to get involved with LYF",
+            type: "array",
+            of: [
+                {
+                    type: "card",
+                },
+            ],
+        },
+        {
+            name: "otherQsHeader",
+            title: "Other Questions Header",
+            type: "text",
+        },
+        {
+            name: "otherQsBody",
+            title: "Other Questions Body",
+            type: "portableText",
+        },
+        {
+            name: "otherQsLink",
+            title: "Other Questions Button",
+            type: "button",
+        }
+    ],
+}
+
+export default schema


### PR DESCRIPTION
This PR adds the schema for the Get Involved page according to this [Figma](https://www.figma.com/file/p3jTW66oX0UTb9uHKXjTFm/LYF-Website-Brainstorm). Closes #14.