### PR TITLE
Add schema for history page

### DIFF
--- a/schemas/singletons/about-us/historyPage.ts
+++ b/schemas/singletons/about-us/historyPage.ts
@@ -16,6 +16,23 @@ const schema: DocumentDefinition = {
             title: "Sub Header",
             type: "text",
         },
+        {
+            name: "headerImage",
+            title: "Header Image",
+            description: "Image accompanying 'History' section",
+            type: "image"
+        },
+        {
+            name: "timeline",
+            title: "Timeline",
+            description: "Text and images to display on the history timeline. Title will be used as the date.",
+            type: "array",
+            of: [
+                {
+                    type: "card",
+                },
+            ],
+        }
     ],
 }
 


### PR DESCRIPTION
CMS preview looks right

Overall schema:
<img width="1624" alt="Screenshot 2023-03-08 at 7 35 32 PM" src="https://user-images.githubusercontent.com/8270089/223915289-dce15bd0-7c33-4c4d-9ffb-912296efcd6a.png">

Card schema:
<img width="1624" alt="Screenshot 2023-03-08 at 7 35 27 PM" src="https://user-images.githubusercontent.com/8270089/223915298-ff40c724-f0c1-4b84-b1af-fd148b280cbc.png"> 
