### PR TITLE
Replace cookbook page with reference to product

### DIFF
--- a/schemas/singletons/get-involved/cookbookPage.ts
+++ b/schemas/singletons/get-involved/cookbookPage.ts
@@ -6,15 +6,13 @@ const schema: DocumentDefinition = {
     type: "document",
     fields: [
         {
-            name: "mainHeader",
-            title: "Main Header",
-            type: "string",
+            name: "productReference",
+            title: "Cookbook Document to Display",
+            description:
+                "A reference to the main cookbook version we should display on the cookbook page. Every product will still exist in our database, and we can choose to highlight different cookbooks.",
+            type: "reference",
+            to: [{ type: "product" }],
             validation: (Rule) => Rule.required(),
-        },
-        {
-            name: "subHeader",
-            title: "Sub Header",
-            type: "text",
         },
     ],
 }


### PR DESCRIPTION
# Context

I added the product schema as a document which will allow us to add new versions of the cookbook and also any other merch we'd like to sell on the site

Ideally, we'd be able to use one template for all products on the LYF website and have Gatsby generate unique pages for each of them.

# This PR
For now though, cookbooks are special and have a dedicated shortcut `/cookbook`, so I modified the cookbookPage schema to include a reference to a product. I'm iffy on this implementation cause there's some page duplication but at least it'll be the easiest to start with and eventually adapt