### PR TITLE
Add leadership schemas

### DIFF
--- a/schemas/documents/leadership.ts
+++ b/schemas/documents/leadership.ts
@@ -1,0 +1,28 @@
+import { DocumentDefinition } from "sanity"
+
+const schema: DocumentDefinition = {
+    name: "leadership",
+    title: "Leadership Team",
+    type: "document",
+    fields: [
+        {
+            name: "boardYear",
+            title: "Board Year",
+            type: "reference",
+            to: [{ type: "campYear" }],
+            validation: (Rule) => Rule.required(),
+        },
+        {
+            name: "committees",
+            title: "Committees",
+            type: "array",
+            of: [
+                {
+                    type: "committee",
+                },
+            ],
+        },
+    ],
+}
+
+export default schema

--- a/schemas/objects/committee.ts
+++ b/schemas/objects/committee.ts
@@ -1,0 +1,27 @@
+import { ObjectDefinition } from "sanity"
+
+const schema: ObjectDefinition = {
+    name: "committee",
+    title: "Leadership Committee",
+    type: "object",
+    fields: [
+        {
+            name: "name",
+            title: "Name",
+            type: "string",
+            validation: (Rule) => Rule.required(),
+        },
+        {
+            name: "members",
+            title: "Members",
+            type: "array",
+            of: [
+                {
+                    type: "person",
+                },
+            ],
+        },
+    ],
+}
+
+export default schema

--- a/schemas/objects/person.ts
+++ b/schemas/objects/person.ts
@@ -1,27 +1,15 @@
-import { DocumentDefinition } from "sanity"
+import { ObjectDefinition } from "sanity"
 
-const schema: DocumentDefinition = {
+const schema: ObjectDefinition = {
     name: "person",
     title: "Person",
-    type: "document",
+    type: "object",
     fields: [
         {
             name: "name",
             title: "Name",
             type: "string",
             validation: (Rule) => Rule.required(),
-        },
-        {
-            name: "boardYear",
-            title: "Board Year",
-            type: "reference",
-            to: [{ type: "campYear" }],
-            validation: (Rule) => Rule.required(),
-        },
-        {
-            name: "committee",
-            title: "Committee/Org Level",
-            type: "string",
         },
         {
             name: "position",
@@ -32,18 +20,15 @@ const schema: DocumentDefinition = {
             name: "propic",
             title: "Profile Picture",
             type: "image",
+            options: {
+              hotspot: true,
+            },
         },
         {
             // see https://www.sanity.io/docs/block-type
             name: "description",
             title: "Description",
             type: "portableText",
-        },
-        {
-            name: "order",
-            title: "Order",
-            type: "number",
-            hidden: true,
         },
     ],
 }

--- a/schemas/schema.ts
+++ b/schemas/schema.ts
@@ -13,14 +13,16 @@ import getInvolvedPage from "./singletons/get-involved/getInvolvedPage"
 
 // Import the document schemas
 import campYear from "./documents/campYear"
-import person from "./documents/person"
+import leadership from "./documents/leadership"
 import product from "./documents/product"
 import event from "./documents/event"
 
 // Import the object schemas
 import button from "./objects/button"
 import card from "./objects/card"
+import committee from "./objects/committee"
 import dropdown from "./objects/dropdown"
+import person from "./objects/person"
 import portableText from "./objects/portableText"
 import quote from "./objects/quote"
 import statistic from "./objects/statistic"
@@ -46,14 +48,16 @@ export default [
 
     // Documents
     campYear,
-    person,
-    product,
     event,
+    leadership,
+    product,
 
     // Objects
     button,
     card,
+    committee,
     dropdown,
+    person,
     portableText,
     quote,
     statistic,

--- a/schemas/singletons/about-us/leadershipPage.ts
+++ b/schemas/singletons/about-us/leadershipPage.ts
@@ -16,6 +16,13 @@ const schema: DocumentDefinition = {
             title: "Sub Header",
             type: "text",
         },
+        {
+            name: "leadership",
+            title: "Leadership Team",
+            type: "reference",
+            to: [{ type: "leadership" }],
+            validation: (Rule) => Rule.required(),
+        },
     ],
 }
 


### PR DESCRIPTION
# Figma
![image](https://user-images.githubusercontent.com/8130932/236730535-d8728138-78b0-4dd0-9a76-7e5747c90052.png)

# This PR
Decided to make the leadership schema a document so that we could keep track of multiple years of leadership. Every leadership document has an array of committee objects which is also just an array of person objects. Hopefully this is the most generic structure we could have. It doesn't cover any hierarchy but eh oh well

The leadership page will just contain a reference to a particular leadership document