### PR TITLE
Create pageLinks and upNext fields in relevant pages

### DIFF
--- a/schemas/documents/pageLinks.ts
+++ b/schemas/documents/pageLinks.ts
@@ -1,0 +1,44 @@
+import { DocumentDefinition } from "sanity";
+
+const schema: DocumentDefinition = {
+    name: "pageLinks",
+    title: "Page Links",
+    type: "document",
+    fields: [
+        {
+            name: "header",
+            title: "Header",
+            type: "string",
+            validation: (Rule) => Rule.required(),
+        },
+        {
+            name: "description",
+            title: "Description",
+            type: "text",
+        },
+        {
+            name: "image",
+            title: "Image",
+            type: "image",
+            validation: (Rule) => Rule.required(),
+        },
+        {
+            name: "link",
+            title: "Link",
+            type: "reference",
+            to: [
+                {type: "culturePage"},
+                {type: "historyPage"},
+                {type: "leadershipPage"},
+                {type: "faqPage"},
+                {type: "lyfCampPage"},
+                {type: "cookbookPage"},
+                {type: "donatePage"},
+                {type: "joinOurTeamPage"},
+            ],
+            validation: (Rule) => Rule.required(),
+        },
+    ]
+}
+
+export default schema

--- a/schemas/schema.ts
+++ b/schemas/schema.ts
@@ -16,6 +16,7 @@ import campYear from "./documents/campYear"
 import leadership from "./documents/leadership"
 import product from "./documents/product"
 import event from "./documents/event"
+import pageLinks from "./documents/pageLinks"
 
 // Import the object schemas
 import button from "./objects/button"
@@ -51,6 +52,7 @@ export default [
     event,
     leadership,
     product,
+    pageLinks,
 
     // Objects
     button,

--- a/schemas/singletons/about-us/culturePage.ts
+++ b/schemas/singletons/about-us/culturePage.ts
@@ -51,6 +51,17 @@ const schema: DocumentDefinition = {
                 },
             ]
         },
+        {
+            name: "upNext",
+            title: "Up Next Links",
+            type: "array",
+            of: [
+                {
+                    type: "reference",
+                    to: [{type: "pageLinks"}]
+                }
+            ]
+        },
     ],
 }
 

--- a/schemas/singletons/about-us/historyPage.ts
+++ b/schemas/singletons/about-us/historyPage.ts
@@ -32,7 +32,18 @@ const schema: DocumentDefinition = {
                     type: "card",
                 },
             ],
-        }
+        },
+        {
+            name: "upNext",
+            title: "Up Next Links",
+            type: "array",
+            of: [
+                {
+                    type: "reference",
+                    to: [{type: "pageLinks"}]
+                }
+            ]
+        },
     ],
 }
 

--- a/schemas/singletons/about-us/leadershipPage.ts
+++ b/schemas/singletons/about-us/leadershipPage.ts
@@ -23,6 +23,17 @@ const schema: DocumentDefinition = {
             to: [{ type: "leadership" }],
             validation: (Rule) => Rule.required(),
         },
+        {
+            name: "upNext",
+            title: "Up Next Links",
+            type: "array",
+            of: [
+                {
+                    type: "reference",
+                    to: [{type: "pageLinks"}]
+                }
+            ]
+        },
     ],
 }
 

--- a/schemas/singletons/camp/faqPage.ts
+++ b/schemas/singletons/camp/faqPage.ts
@@ -69,6 +69,17 @@ const schema: DocumentDefinition = {
                 },
             ],
         },
+        {
+            name: "upNext",
+            title: "Up Next Links",
+            type: "array",
+            of: [
+                {
+                    type: "reference",
+                    to: [{type: "pageLinks"}]
+                }
+            ]
+        },
     ],
 }
 

--- a/schemas/singletons/camp/lyfCampPage.ts
+++ b/schemas/singletons/camp/lyfCampPage.ts
@@ -64,6 +64,17 @@ const schema: DocumentDefinition = {
                 },
             ],
         },
+        {
+            name: "upNext",
+            title: "Up Next Links",
+            type: "array",
+            of: [
+                {
+                    type: "reference",
+                    to: [{type: "pageLinks"}]
+                }
+            ]
+        },
     ],
 }
 

--- a/schemas/singletons/get-involved/joinOurTeamPage.ts
+++ b/schemas/singletons/get-involved/joinOurTeamPage.ts
@@ -95,14 +95,14 @@ const schema: DocumentDefinition = {
         },
         {
             name: "upNext",
-            title: "Up Next",
-            description: "Cards shown in the 'Up Next' section",
+            title: "Up Next Links",
             type: "array",
             of: [
                 {
-                    type: "card",
-                },
-            ],
+                    type: "reference",
+                    to: [{type: "pageLinks"}]
+                }
+            ]
         },
     ],
 }


### PR DESCRIPTION
This PR makes pageLinks schema as a document, with a header, description, image, and link, where the link can only be selected from set options. PR also adds upNext fields in the relevant pages and replaces the original upNext field (array of cards) in the "Join Our Team" page to the updated array of pageLinks.